### PR TITLE
add titles for each page and add some additional css to make the formatting on phones a little better

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,6 +2,7 @@
 <html>
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <head>
+  <title>MA SRA | About</title>
   <link rel="stylesheet" type="text/css" href="styles.css">
   <link rel="stylesheet" type="text/css" href="dropdown.css">
   <link rel="icon" type="image/x-icon" href="images/SRA Logo.ico">

--- a/about.html
+++ b/about.html
@@ -21,7 +21,7 @@ function myFunction() {
 
 <body>
   <div class="sidebar">
-    <img class="ma-logo" src="images/MASRATempLogo.png"/>
+    <a href="index.html"><img class="ma-logo" src="images/MASRATempLogo.png"/></a>
     <p class="logo-subtext">
       Socialist Rifle Association
       <br/>

--- a/about.html
+++ b/about.html
@@ -40,13 +40,14 @@ function myFunction() {
   </div>
   <div class="page">
     <div class="navbar", id="topnav">
-    <ul class="navbar">
+      <ul class="navbar">
+      <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
+
       <li class="navbar-li"><a a class="navbar-li-a" href="index.html">Home</a></li>
       <li class="navbar-li"><a a class="navbar-active" href="about.html">About</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" href="projects.html">Projects</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" href="contact.html">Contact</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" id="donate" href="https://opencollective.com/ma_sra" target="_blank">Donate</a></li>
-      <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
     </ul>
     </div>
 

--- a/contact.html
+++ b/contact.html
@@ -22,7 +22,7 @@ function myFunction() {
 
 <body>
   <div class="sidebar">
-    <img class="ma-logo" src="images/MASRATempLogo.png"/>
+    <a href="index.html"><img class="ma-logo" src="images/MASRATempLogo.png"/></a>
     <p class="logo-subtext">
       Socialist Rifle Association
       <br/>

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,7 @@
 <html>
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <head>
+  <title>MA SRA | Contact</title>
   <link rel="stylesheet" type="text/css" href="styles.css">
   <link rel="stylesheet" type="text/css" href="dropdown.css">
   <link rel="stylesheet" type="text/css" href="form_style.css">

--- a/contact.html
+++ b/contact.html
@@ -42,12 +42,13 @@ function myFunction() {
   <div class="page">
     <div class="navbar", id="topnav">
     <ul class="navbar">
+      <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
+
       <li class="navbar-li"><a a class="navbar-li-a" href="index.html">Home</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" href="about.html">About</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" href="projects.html">Projects</a></li>
       <li class="navbar-li"><a a class="navbar-active" href="contact.html">Contact</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" id="donate" href="https://opencollective.com/ma_sra" target="_blank">Donate</a></li>
-      <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
     </ul>
   </div>
 

--- a/dropdown.css
+++ b/dropdown.css
@@ -6,16 +6,21 @@
 
 /* When the screen is less than 600 pixels wide, hide all links, except for the first one ("Home"). Show the link that contains should open and close the navbar (.icon) */
 @media screen and (max-width: 700px) {
-  .navbar {background-color:#333;}
-  .navbar a:not(:first-child), .navbar li:not(:first-child) {
+  .navbar {
+    background-color:#333;
+    position: relative;
+    z-index: 1000;
+    float: right;
+  }
+  .navbar a, .navbar li {
     display: none;
   }
   .navbar a.icon {
     float: right;
     display: block;
-    font-size: 20px;
     text-decoration: none;
     padding: 14px 16px;
+    background-color: #222222;
   }
 }
 
@@ -23,12 +28,17 @@
 @media screen and (max-width: 700px) {
   .navbar.responsive
   {
-    position: relative;
+    position: absolute;
+    right: 32px;
+    z-index: 1000;
+    float: right;
   }
   .navbar.responsive a.icon {
-    position: absolute;
-    right: 0;
-    top: 0;
+    float: right;
+    display: block;
+    text-decoration: none;
+    padding: 14px 16px;
+    background-color: #222222;
   }
   .navbar.responsive li {
     float: none;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <head>
+  <title>MA SRA | Home</title>
   <link rel="stylesheet" type="text/css" href="styles.css">
   <link rel="stylesheet" type="text/css" href="dropdown.css">
   <link rel="icon" type="image/x-icon" href="images/SRA Logo.ico">

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ function myFunction() {
 
 <body>
   <div class="sidebar">
-    <img class="ma-logo" src="images/MASRATempLogo.png"/>
+    <a href="index.html"><img class="ma-logo" src="images/MASRATempLogo.png"/></a>
     <p class="logo-subtext">
       Socialist Rifle Association
       <br/>

--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@ function myFunction() {
   <div class="page">
     <div class="navbar", id="topnav">
       <ul class="navbar">
+        <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
+
         <li class="navbar-li"><a a class="navbar-active" href="index.html">Home</a></li>
         <li class="navbar-li"><a a class="navbar-li-a" href="about.html">About</a></li>
         <li class="navbar-li"><a a class="navbar-li-a" href="projects.html">Projects</a></li>
         <li class="navbar-li"><a a class="navbar-li-a" href="contact.html">Contact</a></li>
         <li class="navbar-li"><a a class="navbar-li-a" id="donate" href="https://opencollective.com/ma_sra" target="_blank">Donate</a></li>
-
-        <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
       </ul>
     </div>
     <div class="content">

--- a/projects.html
+++ b/projects.html
@@ -41,13 +41,13 @@ function myFunction() {
   <div class="page">
     <div class="navbar", id="topnav">
     <ul class="navbar">
+      <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
+
       <li class="navbar-li"><a a class="navbar-li-a" href="index.html">Home</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" href="about.html">About</a></li>
       <li class="navbar-li"><a a class="navbar-active" href="projects.html">Projects</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" href="contact.html">Contact</a></li>
       <li class="navbar-li"><a a class="navbar-li-a" id="donate" href="https://opencollective.com/ma_sra" target="_blank">Donate</a></li>
-
-      <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
     </ul>
   </div>
 

--- a/projects.html
+++ b/projects.html
@@ -2,6 +2,7 @@
 <html>
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <head>
+  <title>MA SRA | Projects</title>
   <link rel="stylesheet" type="text/css" href="styles.css">
   <link rel="stylesheet" type="text/css" href="dropdown.css">
   <link rel="icon" type="image/x-icon" href="images/SRA Logo.ico">

--- a/projects.html
+++ b/projects.html
@@ -21,7 +21,7 @@ function myFunction() {
 
 <body>
   <div class="sidebar">
-    <img class="ma-logo" src="images/MASRATempLogo.png"/>
+    <a href="index.html"><img class="ma-logo" src="images/MASRATempLogo.png"/></a>
     <p class="logo-subtext">
       Socialist Rifle Association
       <br/>

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,8 @@
 
 body {
   background-color: #222222;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .page {
@@ -178,6 +180,10 @@ p {
   .page {
     margin-left: 5%;
     width: 90%;
+  }
+
+  .bg-image {
+    margin-left: -200px;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -182,6 +182,11 @@ p {
     width: 90%;
   }
 
+  .content {
+    position: relative;
+    top: 50%;
+  }
+
   .bg-image {
     margin-left: -200px;
   }

--- a/styles.css
+++ b/styles.css
@@ -119,7 +119,7 @@ p {
   margin-top: 10%;
   margin-left: 12%;
   margin-right: 44%;
-  width: 44%;
+  width: fit-content;
   padding: 5%;
 }
 
@@ -140,6 +140,16 @@ p {
   padding: 10px;
 }
 
+/*
+  At this point the contact links start to overlap with the content on the page.
+  Since this info is reduntant from the contact page anyway, let's just hide it.
+*/
+@media screen and (max-width: 1100px) {
+  .contact-links {
+    display: none;
+  }
+}
+
 .ma-logo {
   width: 60%;
   margin-left: 20%;
@@ -151,6 +161,24 @@ p {
   font-family: Futura, 'Didact Gothic', sans-serif;
   color: #DCDCDCDC;
   text-align: center;
+}
+
+/* Handle mobile screen */
+
+@media screen and (max-width: 600px) {
+  .logo-subtext {
+    display: none;
+  }
+  
+  .sidebar {
+    float: top;
+    width: 30%;
+  }
+
+  .page {
+    margin-left: 5%;
+    width: 90%;
+  }
 }
 
 /* Navbar from W3 schools */


### PR DESCRIPTION
The changes I've made so far are:
- Add titles to every page
- Hide contact info when it starts to overlap the page content
- Make the background of the contact info always fit its contents
- Hide the logo text (Socialist Rifle Association Massachusetts Chapter) if the screen is too narrow
- Fix horizontal scrolling when the window is too small
- Move hammer and sickle over when the screen is too narrow
- Make the logo a link back to the homepage

Other changes I'd like to make:
- Add twitter and email to contact page
- Make the dropdown menu always show the name of the active page instead of "Home" for everything
- Make the dropdown float above the page content when it's open
- Maybe move the dropdown menu to the right of the screen
- Fix the formatting on the contact page